### PR TITLE
feat: add image media metadata and download/decrypt tool

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -11,6 +11,7 @@ export type ApiOptions = {
 const DEFAULT_LONG_POLL_TIMEOUT_MS = 35_000;
 const DEFAULT_API_TIMEOUT_MS = 15_000;
 const QR_LONG_POLL_TIMEOUT_MS = 35_000;
+const DEFAULT_CDN_TIMEOUT_MS = 30_000;
 const CHANNEL_VERSION = "1.0.0";
 
 function ensureTrailingSlash(url: string): string {
@@ -195,4 +196,34 @@ export async function sendTyping(params: {
     timeoutMs: DEFAULT_CONFIG_TIMEOUT_MS,
     label: "sendTyping",
   });
+}
+
+export async function downloadEncryptedMedia(params: {
+  encryptQueryParam: string;
+  timeoutMs?: number;
+}): Promise<Buffer> {
+  const controller = new AbortController();
+  const timeout = params.timeoutMs ?? DEFAULT_CDN_TIMEOUT_MS;
+  const timer = setTimeout(() => controller.abort(), timeout);
+  const url = new URL("https://novac2c.cdn.weixin.qq.com/c2c/download");
+  url.searchParams.set("encrypted_query_param", params.encryptQueryParam);
+
+  try {
+    const response = await fetch(url.toString(), {
+      method: "GET",
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "(unreadable)");
+      throw new Error(`downloadEncryptedMedia ${response.status}: ${body}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  } catch (err) {
+    clearTimeout(timer);
+    throw err;
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { loginQrcode, checkQrcodeStatus, loginQrcodeSchema, checkQrcodeStatusSch
 import { getMessages, getMessagesSchema } from "./tools/messages.js";
 import { sendTextMessage, sendTextMessageSchema } from "./tools/send.js";
 import { sendTypingIndicator, sendTypingSchema } from "./tools/typing.js";
+import { downloadImage, downloadImageSchema } from "./tools/media.js";
 
 const server = new McpServer(
   {
@@ -80,6 +81,15 @@ server.tool(
   sendTypingSchema.shape,
   async (input) => {
     return await sendTypingIndicator(input);
+  },
+);
+
+server.tool(
+  "download_image",
+  "Download and decrypt an image using media fields from get_messages[].media entries. Provide encrypt_query_param and aeskey (hex) or aes_key (base64).",
+  downloadImageSchema.shape,
+  async (input) => {
+    return await downloadImage(input);
   },
 );
 

--- a/src/tools/media.ts
+++ b/src/tools/media.ts
@@ -1,0 +1,102 @@
+import crypto from "node:crypto";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { z } from "zod";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+
+import { downloadEncryptedMedia } from "../api/client.js";
+
+export const downloadImageSchema = z.object({
+  encrypt_query_param: z.string().min(1).describe("Encrypted query param from image_item.media.encrypt_query_param"),
+  aeskey: z.string().optional().describe("Hex AES key from image_item.aeskey (32 hex chars)"),
+  aes_key: z.string().optional().describe("Base64 AES key from image_item.media.aes_key"),
+  save_to: z.string().optional().describe("Optional absolute path to save decrypted image"),
+});
+
+function parseKey(input: { aeskey?: string; aes_key?: string }): Buffer {
+  if (input.aeskey?.trim()) {
+    const hex = input.aeskey.trim();
+    if (!/^[0-9a-fA-F]{32}$/.test(hex)) {
+      throw new McpError(ErrorCode.InvalidParams, "aeskey must be 32 hex chars");
+    }
+    return Buffer.from(hex, "hex");
+  }
+
+  if (!input.aes_key?.trim()) {
+    throw new McpError(ErrorCode.InvalidParams, "Either aeskey or aes_key is required");
+  }
+
+  const raw = Buffer.from(input.aes_key.trim(), "base64");
+  if (raw.length === 16) {
+    return raw;
+  }
+
+  const rawText = raw.toString("utf8").trim();
+  if (/^[0-9a-fA-F]{32}$/.test(rawText)) {
+    return Buffer.from(rawText, "hex");
+  }
+
+  throw new McpError(ErrorCode.InvalidParams, "Unable to parse aes_key as a 16-byte key");
+}
+
+function detectImageMeta(buf: Buffer): { mime: string; extension: string } {
+  if (buf.length >= 8 && buf.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+    return { mime: "image/png", extension: "png" };
+  }
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) {
+    return { mime: "image/jpeg", extension: "jpg" };
+  }
+  if (buf.length >= 12 && buf.subarray(0, 4).toString("ascii") === "RIFF" && buf.subarray(8, 12).toString("ascii") === "WEBP") {
+    return { mime: "image/webp", extension: "webp" };
+  }
+  if (buf.length >= 6) {
+    const head = buf.subarray(0, 6).toString("ascii");
+    if (head === "GIF87a" || head === "GIF89a") {
+      return { mime: "image/gif", extension: "gif" };
+    }
+  }
+  return { mime: "application/octet-stream", extension: "bin" };
+}
+
+export async function downloadImage(input: {
+  encrypt_query_param: string;
+  aeskey?: string;
+  aes_key?: string;
+  save_to?: string;
+}): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  const key = parseKey(input);
+  const encrypted = await downloadEncryptedMedia({ encryptQueryParam: input.encrypt_query_param });
+
+  const decipher = crypto.createDecipheriv("aes-128-ecb", key, null);
+  decipher.setAutoPadding(true);
+  const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+
+  const meta = detectImageMeta(decrypted);
+  let savedPath: string | undefined;
+  if (input.save_to?.trim()) {
+    const finalPath = input.save_to.trim();
+    await writeFile(finalPath, decrypted);
+    savedPath = path.resolve(finalPath);
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            success: true,
+            size: decrypted.length,
+            mime: meta.mime,
+            extension: meta.extension,
+            saved_path: savedPath,
+            base64: decrypted.toString("base64"),
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -103,23 +103,61 @@ export async function getMessages(input: { wait?: boolean; timeout?: number }): 
 function formatMessage(msg: WeixinMessage) {
   const items = msg.item_list ?? [];
   const textParts: string[] = [];
+  const media: Array<{
+    kind: "image" | "voice" | "file" | "video";
+    index: number;
+    url?: string;
+    file_name?: string;
+    text?: string;
+    encrypt_query_param?: string;
+    aes_key?: string;
+    aeskey?: string;
+  }> = [];
 
-  for (const item of items) {
+  for (const [index, item] of items.entries()) {
     switch (item.type) {
       case 1:
         textParts.push(item.text_item?.text ?? "");
         break;
       case 2:
         textParts.push("[Image]");
+        media.push({
+          kind: "image",
+          index,
+          url: item.image_item?.url,
+          encrypt_query_param: item.image_item?.media?.encrypt_query_param,
+          aes_key: item.image_item?.media?.aes_key,
+          aeskey: item.image_item?.aeskey,
+        });
         break;
       case 3:
         textParts.push(item.voice_item?.text ? `[Voice: ${item.voice_item.text}]` : "[Voice]");
+        media.push({
+          kind: "voice",
+          index,
+          text: item.voice_item?.text,
+          encrypt_query_param: item.voice_item?.media?.encrypt_query_param,
+          aes_key: item.voice_item?.media?.aes_key,
+        });
         break;
       case 4:
         textParts.push(item.file_item?.file_name ? `[File: ${item.file_item.file_name}]` : "[File]");
+        media.push({
+          kind: "file",
+          index,
+          file_name: item.file_item?.file_name,
+          encrypt_query_param: item.file_item?.media?.encrypt_query_param,
+          aes_key: item.file_item?.media?.aes_key,
+        });
         break;
       case 5:
         textParts.push("[Video]");
+        media.push({
+          kind: "video",
+          index,
+          encrypt_query_param: item.video_item?.media?.encrypt_query_param,
+          aes_key: item.video_item?.media?.aes_key,
+        });
         break;
     }
   }
@@ -138,6 +176,7 @@ function formatMessage(msg: WeixinMessage) {
     to_user_id: msg.to_user_id,
     type: msg.message_type === 1 ? "received" : "sent",
     text,
+    media,
     context_token: msg.context_token,
     create_time: msg.create_time_ms ? new Date(msg.create_time_ms).toISOString() : undefined,
   };


### PR DESCRIPTION
## Summary
- add `download_image` MCP tool to download encrypted CDN media and decrypt image payload with AES-128-ECB
- enrich `get_messages` output with `media` metadata (including `encrypt_query_param`, `aes_key`/`aeskey`) for image/voice/file/video items
- wire the new tool in `src/index.ts` and add media helper implementation in `src/tools/media.ts`

## Validation
- ran `bun install` successfully
- started MCP server and verified tools list now includes `download_image`